### PR TITLE
Added INISerializer, which help benedict parsing and writing to .ini

### DIFF
--- a/benedict/dicts/io/io_dict.py
+++ b/benedict/dicts/io/io_dict.py
@@ -39,15 +39,17 @@ class IODict(BaseDict):
                 return data
             elif type_util.is_list(data):
                 # force list to dict
-                return {'values': data}
+                return {
+                    'values': data
+                }
             else:
                 raise ValueError(
-                    'Invalid data type: {}, expected dict or list.'.format(
-                        type(data)))
+                        'Invalid data type: {}, expected dict or list.'.format(
+                                type(data)))
         except Exception as e:
             raise ValueError(
-                'Invalid data or url or filepath argument: {}\n{}'.format(
-                    s, e))
+                    'Invalid data or url or filepath argument: {}\n{}'.format(
+                            s, e))
 
     @staticmethod
     def _encode(d, format, **kwargs):
@@ -182,6 +184,16 @@ class IODict(BaseDict):
         A ValueError is raised in case of failure.
         """
         return self._encode(self, 'json', **kwargs)
+
+    def to_ini(self, **kwargs):
+        """
+        Encode the current dict instance in JSON format.
+        Encoder specific options can be passed using kwargs:
+        https://docs.python.org/3/library/json.html
+        Return the encoded string and optionally save it at 'filepath'.
+        A ValueError is raised in case of failure.
+        """
+        return self._encode(self, 'ini', **kwargs)
 
     def to_pickle(self, **kwargs):
         """

--- a/benedict/dicts/io/io_dict.py
+++ b/benedict/dicts/io/io_dict.py
@@ -84,6 +84,15 @@ class IODict(BaseDict):
         return cls(s, format='csv', **kwargs)
 
     @classmethod
+    def from_ini(cls, s, **kwargs):
+        """
+        Load and decode .ini data from url, filepath or data-string.
+        Decoder specific options can be passed using kwargs.
+        Return a new dict instance. A ValueError is raised in case of failure.
+        """
+        return cls(s, format='ini', **kwargs)
+
+    @classmethod
     def from_json(cls, s, **kwargs):
         """
         Load and decode JSON data from url, filepath or data-string.
@@ -187,9 +196,9 @@ class IODict(BaseDict):
 
     def to_ini(self, **kwargs):
         """
-        Encode the current dict instance in JSON format.
-        Encoder specific options can be passed using kwargs:
-        https://docs.python.org/3/library/json.html
+        Encode the current dict instance in INI format.
+        Encoder specific options can be passed using kwargs: (method 'write')
+        https://docs.python.org/3/library/configparser.html
         Return the encoded string and optionally save it at 'filepath'.
         A ValueError is raised in case of failure.
         """

--- a/benedict/serializers/__init__.py
+++ b/benedict/serializers/__init__.py
@@ -3,6 +3,7 @@
 from benedict.serializers.abstract import AbstractSerializer
 from benedict.serializers.base64 import Base64Serializer
 from benedict.serializers.csv import CSVSerializer
+from benedict.serializers.ini import INISerializer
 from benedict.serializers.json import JSONSerializer
 from benedict.serializers.pickle import PickleSerializer
 from benedict.serializers.plist import PListSerializer
@@ -17,6 +18,7 @@ import re
 _BASE64_SERIALIZER = Base64Serializer()
 _CSV_SERIALIZER = CSVSerializer()
 _JSON_SERIALIZER = JSONSerializer()
+_INI_SERIALIZER = INISerializer()
 _PICKLE_SERIALIZER = PickleSerializer()
 _PLIST_SERIALIZER = PListSerializer()
 _QUERY_STRING_SERIALIZER = QueryStringSerializer()
@@ -37,6 +39,7 @@ _SERIALIZERS = {
     'yaml': _YAML_SERIALIZER,
     'yml': _YAML_SERIALIZER,
     'xml': _XML_SERIALIZER,
+    'ini': _INI_SERIALIZER,
 }
 
 _SERIALIZERS_EXTENSIONS = [

--- a/benedict/serializers/__init__.py
+++ b/benedict/serializers/__init__.py
@@ -17,8 +17,8 @@ import re
 
 _BASE64_SERIALIZER = Base64Serializer()
 _CSV_SERIALIZER = CSVSerializer()
-_JSON_SERIALIZER = JSONSerializer()
 _INI_SERIALIZER = INISerializer()
+_JSON_SERIALIZER = JSONSerializer()
 _PICKLE_SERIALIZER = PickleSerializer()
 _PLIST_SERIALIZER = PListSerializer()
 _QUERY_STRING_SERIALIZER = QueryStringSerializer()
@@ -30,6 +30,7 @@ _SERIALIZERS = {
     'b64': _BASE64_SERIALIZER,
     'base64': _BASE64_SERIALIZER,
     'csv': _CSV_SERIALIZER,
+    'ini': _INI_SERIALIZER,
     'json': _JSON_SERIALIZER,
     'pickle': _PICKLE_SERIALIZER,
     'plist': _PLIST_SERIALIZER,
@@ -39,7 +40,6 @@ _SERIALIZERS = {
     'yaml': _YAML_SERIALIZER,
     'yml': _YAML_SERIALIZER,
     'xml': _XML_SERIALIZER,
-    'ini': _INI_SERIALIZER,
 }
 
 _SERIALIZERS_EXTENSIONS = [

--- a/benedict/serializers/ini.py
+++ b/benedict/serializers/ini.py
@@ -3,11 +3,10 @@
 from __future__ import absolute_import
 
 import io
-from copy import deepcopy
-
-from benedict.serializers.abstract import AbstractSerializer
-
 import configparser
+
+from benedict.core import clone
+from benedict.serializers.abstract import AbstractSerializer
 
 
 class INISerializer(AbstractSerializer):
@@ -55,7 +54,7 @@ class INISerializer(AbstractSerializer):
         }
         for key, value in d.items():
             if isinstance(value, dict):
-                sections[key] = deepcopy(value)
+                sections[key] = clone(value)
             else:
                 sections[default_namespace][key] = value
 

--- a/benedict/serializers/ini.py
+++ b/benedict/serializers/ini.py
@@ -30,7 +30,7 @@ class INISerializer(AbstractSerializer):
             data.seek(0)
             return data.getvalue()
 
-    def _preprocessed_dict(self, d: Dict, default_namespace="default"):
+    def _preprocessed_dict(self, d, default_namespace="default"):
         sections = {
             default_namespace: {}
         }

--- a/benedict/serializers/ini.py
+++ b/benedict/serializers/ini.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import io
-from typing import Dict
+from copy import deepcopy
 
 from benedict.serializers.abstract import AbstractSerializer
 
@@ -15,16 +15,35 @@ class INISerializer(AbstractSerializer):
     def __init__(self):
         super(INISerializer, self).__init__()
 
+    @staticmethod
+    def _try_parse(parser: configparser.ConfigParser, section, key):
+        try:
+            return parser.getint(section, key)
+        except ValueError:
+            try:
+                return parser.getfloat(section, key)
+            except ValueError:
+                try:
+                    return parser.getboolean(section, key)
+                except ValueError:
+                    return parser.get(section, key)
+
     def decode(self, s, **kwargs):
         parser = configparser.ConfigParser()
         kwargs.setdefault("source", "<string>")
         parser.read_string(s, **kwargs)
-        data = {s: dict(parser.items(s)) for s in parser.sections()}
+        data = {}
+        for s in parser.sections():
+            data[s] = {}
+            for key, _ in parser.items(s):
+                data[s][key] = INISerializer._try_parse(parser, s, key)
+
         return data
 
     def encode(self, d, **kwargs):
         parser = configparser.ConfigParser()
-        parser.read_dict(self._preprocessed_dict(d, **kwargs))
+        processed_dict = self._preprocessed_dict(d, **kwargs)
+        parser.read_dict(processed_dict)
         with io.StringIO() as data:
             parser.write(data, **kwargs)
             data.seek(0)
@@ -36,13 +55,17 @@ class INISerializer(AbstractSerializer):
         }
         for key, value in d.items():
             if isinstance(value, dict):
-                sections[key] = value
+                sections[key] = deepcopy(value)
             else:
                 sections[default_namespace][key] = value
 
+        # Stringify all the value
         for section in sections.values():
             for key, val in section.items():
-                if isinstance(val, object):
-                    section[key] = str(val)
+                section[key] = str(val)
+
+        # if the default section is empty, delete it
+        if len(sections[default_namespace]) == 0:
+            del sections[default_namespace]
 
         return sections

--- a/benedict/serializers/ini.py
+++ b/benedict/serializers/ini.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import io
+from typing import Dict
+
+from benedict.serializers.abstract import AbstractSerializer
+
+import configparser
+
+
+class INISerializer(AbstractSerializer):
+
+    def __init__(self):
+        super(INISerializer, self).__init__()
+
+    def decode(self, s, **kwargs):
+        parser = configparser.ConfigParser()
+        kwargs.setdefault("source", "<string>")
+        parser.read_string(s, **kwargs)
+        data = {s: dict(parser.items(s)) for s in parser.sections()}
+        return data
+
+    def encode(self, d, **kwargs):
+        parser = configparser.ConfigParser()
+        parser.read_dict(self._preprocessed_dict(d, **kwargs))
+        with io.StringIO() as data:
+            parser.write(data, **kwargs)
+            data.seek(0)
+            return data.getvalue()
+
+    def _preprocessed_dict(self, d: Dict, default_namespace="default"):
+        sections = {
+            default_namespace: {}
+        }
+        for key, value in d.items():
+            if isinstance(value, dict):
+                sections[key] = value
+            else:
+                sections[default_namespace][key] = value
+
+        for section in sections.values():
+            for key, val in section.items():
+                if isinstance(val, object):
+                    section[key] = str(val)
+
+        return sections

--- a/tests/dicts/io/input/invalid-content.ini
+++ b/tests/dicts/io/input/invalid-content.ini
@@ -1,0 +1,2 @@
+{test}
+abc = def

--- a/tests/dicts/io/input/valid-content.ini
+++ b/tests/dicts/io/input/valid-content.ini
@@ -1,0 +1,9 @@
+[section_a]
+b: 1
+c: helloworld
+[section_b]
+c: 2.5
+f: True
+g: true
+h: false
+j: False

--- a/tests/dicts/io/input/valid-content.ini
+++ b/tests/dicts/io/input/valid-content.ini
@@ -1,6 +1,6 @@
 [section_a]
 b: 1
-c: helloworld
+c: hếllôworlđ
 [section_b]
 c: 2.5
 f: True

--- a/tests/dicts/io/test_io_dict_ini.py
+++ b/tests/dicts/io/test_io_dict_ini.py
@@ -18,8 +18,6 @@ TARGET_DICT = {
     }
 }
 
-
-
 INI_STR = """
         [section_a]
         b: 1

--- a/tests/dicts/io/test_io_dict_ini.py
+++ b/tests/dicts/io/test_io_dict_ini.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+from benedict.dicts.io import IODict
+
+from .test_io_dict import io_dict_test_case
+
+TARGET_DICT = {
+    "section_a": {
+        "b": 1,
+        "c": "helloworld"
+    },
+    "section_b": {
+        "c": 2.5,
+        "f": True,
+        "g": True,
+        "h": False,
+        "j": False
+    }
+}
+
+
+
+INI_STR = """
+        [section_a]
+        b: 1
+        c: helloworld
+        [section_b]
+        c: 2.5
+        f: True
+        g: true
+        h: false
+        j: False
+        """
+
+INVALID_INI_STR = """
+    {test}
+    abc = def 
+    """
+
+
+class io_dict_ini_test_case(io_dict_test_case):
+
+    def test_from_ini_with_valid_data(self):
+        # static method
+        d = IODict.from_ini(INI_STR)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, TARGET_DICT)
+        # constructor
+        d = IODict(INI_STR, format='ini')
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, TARGET_DICT)
+
+    def test_from_ini_with_invalid_data(self):
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_ini(INVALID_INI_STR)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(INVALID_INI_STR, format='ini')
+
+    def test_from_ini_with_valid_file_valid_content(self):
+        filepath = self.input_path('valid-content.ini')
+        # static method
+        d = IODict.from_ini(filepath)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, TARGET_DICT)
+        # constructor
+        d = IODict(filepath, format='ini')
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, TARGET_DICT)
+        # constructor with format autodetection
+        d = IODict(filepath)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, TARGET_DICT)
+
+    def test_from_ini_with_valid_file_valid_content_invalid_format(self):
+        filepath = self.input_path('valid-content.base64')
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        filepath = self.input_path('valid-content.json')
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        filepath = self.input_path('valid-content.qs')
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        filepath = self.input_path('valid-content.toml')
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        filepath = self.input_path('valid-content.xml')
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+
+    def test_from_ini_with_valid_file_invalid_content(self):
+        filepath = self.input_path('invalid-content.ini')
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(filepath, format='ini')
+
+    def test_from_ini_with_invalid_file(self):
+        filepath = self.input_path('invalid-file.ini')
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_ini(filepath)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(filepath, format='ini')
+
+    def test_from_ini_with_valid_url_valid_content(self):
+        url = self.input_url('valid-content.ini')
+        # static method
+        d = IODict.from_ini(url)
+        self.assertTrue(isinstance(d, dict))
+        # constructor
+        d = IODict(url, format='ini')
+        self.assertTrue(isinstance(d, dict))
+        # constructor with format autodetection
+        d = IODict(url)
+        self.assertTrue(isinstance(d, dict))
+
+    def test_from_ini_with_valid_url_invalid_content(self):
+        url = 'https://github.com/fabiocaccamo/python-benedict'
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_ini(url)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(url, format='ini')
+
+    def test_from_ini_with_invalid_url(self):
+        url = 'https://github.com/fabiocaccamo/python-benedict-invalid'
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_ini(url)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(url, format='ini')
+
+    def test_to_ini(self):
+        d = IODict(TARGET_DICT)
+        s = d.to_ini()
+        self.assertEqual(d, IODict.from_ini(s))
+
+    def test_to_ini_file(self):
+        d = IODict(TARGET_DICT)
+        filepath = self.output_path('test_to_ini_file.ini')
+        d.to_ini(filepath=filepath)
+        self.assertFileExists(filepath)
+        self.assertEqual(d, IODict.from_ini(filepath))

--- a/tests/dicts/io/test_io_dict_ini.py
+++ b/tests/dicts/io/test_io_dict_ini.py
@@ -7,7 +7,7 @@ from .test_io_dict import io_dict_test_case
 TARGET_DICT = {
     "section_a": {
         "b": 1,
-        "c": "helloworld"
+        "c": "hếllôworlđ"
     },
     "section_b": {
         "c": 2.5,
@@ -21,7 +21,7 @@ TARGET_DICT = {
 INI_STR = """
         [section_a]
         b: 1
-        c: helloworld
+        c: hếllôworlđ
         [section_b]
         c: 2.5
         f: True
@@ -34,6 +34,25 @@ INVALID_INI_STR = """
     {test}
     abc = def 
     """
+
+TARGET_DICT_WITH_OBJ = {
+    "section_a": {
+        "b": [1, 2, 3],
+        "c": {
+            "d": "e"
+        }
+    },
+    "f": "g"
+}
+
+INI_STR_WITH_OBJECT = """[default]
+f = g
+
+[section_a]
+b = [1, 2, 3]
+c = {'d': 'e'}
+
+"""
 
 
 class io_dict_ini_test_case(io_dict_test_case):
@@ -140,6 +159,11 @@ class io_dict_ini_test_case(io_dict_test_case):
         d = IODict(TARGET_DICT)
         s = d.to_ini()
         self.assertEqual(d, IODict.from_ini(s))
+        d = IODict(TARGET_DICT_WITH_OBJ)
+        # We won't have any mechanism to convert a stringified representation of an object back to the object itself,
+        # because of the limited capability of ini files to store data.
+        # If you need to store complicated objects, use other format.
+        self.assertEqual(d.to_ini(), INI_STR_WITH_OBJECT)
 
     def test_to_ini_file(self):
         d = IODict(TARGET_DICT)

--- a/tests/serializers/test_ini_serializer.py
+++ b/tests/serializers/test_ini_serializer.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from benedict.serializers import INISerializer, PickleSerializer
+from benedict.serializers import INISerializer
 from benedict.utils import type_util
-
-import datetime as dt
 import unittest
 
 TARGET_DICT = {
     "section_a": {
         "b": 1,
-        "c": "helloworld"
+        "c": "hếllôworlđ"
     },
     "section_b": {
         "c": 2.5,
@@ -20,7 +18,7 @@ TARGET_DICT = {
 
 INI_STR = """[section_a]
 b = 1
-c = helloworld
+c = hếllôworlđ
 
 [section_b]
 c = 2.5
@@ -39,8 +37,8 @@ class ini_serializer_test_case(unittest.TestCase):
         s = INISerializer().encode(TARGET_DICT)
         self.assertEqual(s, INI_STR)
 
-    def test_encode_decode_pickle(self):
-        serializer = PickleSerializer()
+    def test_encode_decode_ini(self):
+        serializer = INISerializer()
         s = serializer.encode(TARGET_DICT)
         self.assertTrue(type_util.is_string(s))
         r = serializer.decode(s)

--- a/tests/serializers/test_ini_serializer.py
+++ b/tests/serializers/test_ini_serializer.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from benedict.serializers import INISerializer, PickleSerializer
+from benedict.utils import type_util
+
+import datetime as dt
+import unittest
+
+TARGET_DICT = {
+    "section_a": {
+        "b": 1,
+        "c": "helloworld"
+    },
+    "section_b": {
+        "c": 2.5,
+        "d": True,
+        "e": False,
+    }
+}
+
+INI_STR = """[section_a]
+b = 1
+c = helloworld
+
+[section_b]
+c = 2.5
+d = True
+e = False
+
+"""
+
+
+class ini_serializer_test_case(unittest.TestCase):
+    def test_decode_pickle(self):
+        d = INISerializer().decode(INI_STR)
+        self.assertEqual(d, TARGET_DICT)
+
+    def test_encode_pickle(self):
+        s = INISerializer().encode(TARGET_DICT)
+        self.assertEqual(s, INI_STR)
+
+    def test_encode_decode_pickle(self):
+        serializer = PickleSerializer()
+        s = serializer.encode(TARGET_DICT)
+        self.assertTrue(type_util.is_string(s))
+        r = serializer.decode(s)
+        self.assertTrue(type_util.is_dict(r))
+        self.assertEqual(TARGET_DICT, r)


### PR DESCRIPTION
Parse and write `.ini` file with ConfigParser.
When writing object to `.ini` file, I've process the data by the following rule:
For all the key-value pair in the dict:
- If the value is a not a dict, put them into the default namespace, specified by the `default_namespace` argument
- If the value is a dict, put the dict as a new section
Then run through the sections, if a value is an object, turn it into string.