### PR TITLE
🐛 Add a broken unit test in 0.24.1

### DIFF
--- a/tests/dicts/test_assign.py
+++ b/tests/dicts/test_assign.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from benedict import benedict
+
+
+class assign_test_case(unittest.TestCase):
+    def test__assign__(self):
+        required_fields_to_linkages = {
+            "in_scope": {"output_key": "scope", "fields": ["pk"]},
+            "out_network": {"output_key": "network", "fields": ["pk"]},
+            "in_commonsite": {
+                "output_key": "common_site",
+                "fields": ["pk", "common_site_id_number"],
+            },
+            "out_activity": {"output_key": "activity", "fields": ["pk"]},
+            "in_subproject": {"output_key": "sub_project", "fields": ["pk"]},
+        }
+        new_linkage = benedict({"list": {}})
+
+        output_config = required_fields_to_linkages["in_scope"]
+        output_key = output_config["output_key"]
+        new_linkage["list"][output_key] = {}
+
+        for output_field in output_config["fields"]:
+            new_linkage["list"][output_key][output_field] = None
+            self.assertTrue(True)
+
+


### PR DESCRIPTION
Hi @fabiocaccamo 

The latest 0.24.1 broke something in my Django project.

I did a demo video showing you how I replicated the issue in a unit test. https://www.loom.com/share/1d50cce1764040658d9e9fe4747f9424

This fork also contains my unit test. Please feel free to go through.

Thank you