### PR TITLE
🐛Fix json.dumps(d) and empty dict assignment bug

### DIFF
--- a/benedict/dicts/base/base_dict.py
+++ b/benedict/dicts/base/base_dict.py
@@ -7,7 +7,7 @@ class BaseDict(dict):
     _pointer = False
 
     def __init__(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], dict) and args[0]:
+        if len(args) == 1 and isinstance(args[0], dict):
             self._dict = args[0].dict() if issubclass(
                 type(args[0]), BaseDict) else args[0]
             self._pointer = True
@@ -65,7 +65,6 @@ class BaseDict(dict):
     def __setitem__(self, key, value):
         if self._pointer:
             self._dict[key] = value
-            return
         super(BaseDict, self).__setitem__(key, value)
 
     def __str__(self):

--- a/tests/github/test_issue_0059.py
+++ b/tests/github/test_issue_0059.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import json
+import unittest
+
+from benedict import benedict
+
+
+class github_issue_0059_test_case(unittest.TestCase):
+
+    """
+    https://github.com/fabiocaccamo/python-benedict/issues/59
+
+    To run this specific test:
+    - Run python -m unittest tests.github.test_issue_0059
+    """
+    def test_init_with_empty_dict_then_merge_with_dict_should_affect_both_dicts(self):
+        initial_empty_dict = {}
+        the_benedict = benedict(initial_empty_dict)
+        the_benedict.merge({"foo": "bar"})
+
+
+        self.assertEqual(initial_empty_dict, {"foo": "bar"})
+        self.assertEqual(the_benedict, {"foo": "bar"})
+
+    def test_init_empty_dict_then_assign_another_empty_dict_as_first_key_should_work(self):
+        d = benedict()
+        # these two lines are inefficient
+        # d["a"] = {"b": {}} is better. Regardless, will test both
+        d["a"] = {}
+        d["a"]["b"] = {}
+
+        self.assertEqual(d, {'a': {'b': {}}})
+
+        d2 = benedict()
+        d2["a"] = {"b": {}}
+
+        self.assertEqual(d2, {'a': {'b': {}}})


### PR DESCRIPTION
issue #57  was to fix json.dumps(d) but it chose the wrong solution therefore causing issue #59 which was bugs involving empty dict assigned as args[0] or assigned to any of the keys.

The correct solution is to remove extra `return` in `__setitem__`

This should close #57 and close #59 after merge to master branch