### PR TITLE
found a fix: i think keypath_separator is inconsistely changing between "." and "_"

### DIFF
--- a/benedict/core/flatten.py
+++ b/benedict/core/flatten.py
@@ -6,7 +6,7 @@ from benedict.utils import type_util
 
 def _flatten_key(base_key, key, separator):
     if base_key and separator:
-        return '{}{}{}'.format(base_key, separator, key)
+        return "{}{}{}".format(base_key, separator, key)
     return key
 
 
@@ -17,23 +17,15 @@ def _flatten_item(d, base_dict, base_key, separator):
         new_key = _flatten_key(base_key, key, separator)
         value = d.get(key, None)
         if type_util.is_dict(value):
-            new_value = _flatten_item(value,
-                                      base_dict=new_dict,
-                                      base_key=new_key,
-                                      separator=separator)
+            new_value = _flatten_item(value, base_dict=new_dict, base_key=new_key, separator=separator)
             new_dict.update(new_value)
             continue
         if new_key in new_dict:
-            raise KeyError(
-                'Invalid key: "{}", key already in flatten dict.'.format(
-                    new_key))
+            raise KeyError('Invalid key: "{}", key already in flatten dict.'.format(new_key))
         new_dict[new_key] = value
     return new_dict
 
 
-def flatten(d, separator='_'):
+def flatten(d, separator="."):
     new_dict = clone(d, empty=True)
-    return _flatten_item(d,
-                         base_dict=new_dict,
-                         base_key='',
-                         separator=separator)
+    return _flatten_item(d, base_dict=new_dict, base_key="", separator=separator)

--- a/benedict/core/unflatten.py
+++ b/benedict/core/unflatten.py
@@ -8,11 +8,17 @@ from benedict.utils import type_util
 def _unflatten_item(key, value, separator):
     keys = key.split(separator)
     if type_util.is_dict(value):
-        return (keys, unflatten(value, separator=separator), )
-    return (keys, value, )
+        return (
+            keys,
+            unflatten(value, separator=separator),
+        )
+    return (
+        keys,
+        value,
+    )
 
 
-def unflatten(d, separator='_'):
+def unflatten(d, separator="."):
     new_dict = clone(d, empty=True)
     keys = list(d.keys())
     for key in keys:

--- a/benedict/dicts/__init__.py
+++ b/benedict/dicts/__init__.py
@@ -31,14 +31,13 @@ from benedict.dicts.parse import ParseDict
 
 
 class benedict(KeypathDict, IODict, ParseDict):
-
     def __init__(self, *args, **kwargs):
         """
         Constructs a new instance.
         """
         if len(args) == 1 and isinstance(args[0], benedict):
             obj = args[0]
-            kwargs.setdefault('keypath_separator', obj.keypath_separator)
+            kwargs.setdefault("keypath_separator", obj.keypath_separator)
             super(benedict, self).__init__(obj.dict(), **kwargs)
             return
         super(benedict, self).__init__(*args, **kwargs)
@@ -50,8 +49,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         return obj
 
     def __getitem__(self, key):
-        return self._cast(
-            super(benedict, self).__getitem__(key))
+        return self._cast(super(benedict, self).__getitem__(key))
 
     def _cast(self, value):
         """
@@ -59,9 +57,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         keeping the pointer to the original dict.
         """
         if isinstance(value, dict) and not isinstance(value, benedict):
-            return benedict(value,
-                            keypath_separator=self._keypath_separator,
-                            check_keys=False)
+            return benedict(value, keypath_separator=self._keypath_separator, check_keys=False)
         return value
 
     def clean(self, strings=True, collections=True):
@@ -76,15 +72,13 @@ class benedict(KeypathDict, IODict, ParseDict):
         """
         Creates and return a clone of the current dict instance (deep copy).
         """
-        return self._cast(
-            _clone(self))
+        return self._cast(_clone(self))
 
     def copy(self):
         """
         Creates and return a copy of the current instance (shallow copy).
         """
-        return self._cast(
-            super(benedict, self).copy())
+        return self._cast(super(benedict, self).copy())
 
     def deepcopy(self):
         """
@@ -119,7 +113,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         """
         return _find(self, keys, default)
 
-    def flatten(self, separator='_'):
+    def flatten(self, separator="."):
         """
         Return a new flattened dict using the given separator
         to join nested dict keys to flatten keypaths.
@@ -127,24 +121,19 @@ class benedict(KeypathDict, IODict, ParseDict):
         return _flatten(self, separator)
 
     def get(self, key, default=None):
-        return self._cast(
-            super(benedict, self).get(key, default))
+        return self._cast(super(benedict, self).get(key, default))
 
     def get_dict(self, key, default=None):
-        return self._cast(
-            super(benedict, self).get_dict(key, default))
+        return self._cast(super(benedict, self).get_dict(key, default))
 
-    def get_list_item(self, key, index=0, default=None, separator=','):
-        return self._cast(
-            super(benedict, self).get_list_item(
-                key, index, default, separator))
+    def get_list_item(self, key, index=0, default=None, separator=","):
+        return self._cast(super(benedict, self).get_list_item(key, index, default, separator))
 
     def groupby(self, key, by_key):
         """
         Group a list of dicts at key by the value of the given by_key and return a new dict.
         """
-        return self._cast(
-            _groupby(self[key], by_key))
+        return self._cast(_groupby(self[key], by_key))
 
     def invert(self, flat=False):
         """
@@ -173,8 +162,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         Return a list of all keypaths in the dict.
         If indexes is True, the output will include list values indexes.
         """
-        return _keypaths(
-            self, separator=self._keypath_separator, indexes=indexes)
+        return _keypaths(self, separator=self._keypath_separator, indexes=indexes)
 
     def match(self, pattern, indexes=True):
         """
@@ -182,8 +170,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         If pattern is string, wildcard can be used (eg. [*] can be used to match all list indexes).
         If indexes is True, the pattern will be matched also against list values.
         """
-        return _match(
-            self, pattern, separator=self._keypath_separator, indexes=indexes)
+        return _match(self, pattern, separator=self._keypath_separator, indexes=indexes)
 
     def merge(self, other, *args, **kwargs):
         """
@@ -201,8 +188,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         """
         _move(self, key_src, key_dest)
 
-    def nest(self, key,
-             id_key='id', parent_id_key='parent_id', children_key='children'):
+    def nest(self, key, id_key="id", parent_id_key="parent_id", children_key="children"):
         """
         Nest a list of dicts at the given key and return a new nested list
         using the specified keys to establish the correct items hierarchy.
@@ -210,8 +196,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         return _nest(self[key], id_key, parent_id_key, children_key)
 
     def pop(self, key, *args):
-        return self._cast(
-            super(benedict, self).pop(key, *args))
+        return self._cast(super(benedict, self).pop(key, *args))
 
     def remove(self, keys, *args):
         """
@@ -221,8 +206,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         _remove(self, keys, *args)
 
     def setdefault(self, key, default=None):
-        return self._cast(
-            super(benedict, self).setdefault(key, default))
+        return self._cast(super(benedict, self).setdefault(key, default))
 
     def rename(self, key, key_new):
         """
@@ -231,9 +215,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         """
         _rename(self, key, key_new)
 
-    def search(self, query,
-               in_keys=True, in_values=True,
-               exact=False, case_sensitive=False):
+    def search(self, query, in_keys=True, in_values=True, exact=False, case_sensitive=False):
         """
         Search and return a list of items (dict, key, value, ) matching the given query.
         """
@@ -265,7 +247,7 @@ class benedict(KeypathDict, IODict, ParseDict):
         """
         _traverse(self, callback)
 
-    def unflatten(self, separator='_'):
+    def unflatten(self, separator="."):
         """
         Return a new unflattened dict using the given separator
         to split dict keys to nested keypaths.

--- a/tests/core/test_flatten.py
+++ b/tests/core/test_flatten.py
@@ -6,67 +6,66 @@ import unittest
 
 
 class flatten_test_case(unittest.TestCase):
-
     def test_flatten(self):
         i = {
-            'a': 1,
-            'b': 2,
-            'c': {
-                'd': {
-                    'e': 3,
-                    'f': 4,
-                    'g': {
-                        'h': 5,
-                    }
+            "a": 1,
+            "b": 2,
+            "c": {
+                "d": {
+                    "e": 3,
+                    "f": 4,
+                    "g": {
+                        "h": 5,
+                    },
                 }
             },
         }
         o = _flatten(i)
         r = {
-            'a': 1,
-            'b': 2,
-            'c_d_e': 3,
-            'c_d_f': 4,
-            'c_d_g_h': 5,
+            "a": 1,
+            "b": 2,
+            "c.d.e": 3,
+            "c.d.f": 4,
+            "c.d.g.h": 5,
         }
         self.assertEqual(o, r)
 
     def test_flatten_with_custom_separator(self):
         i = {
-            'a': 1,
-            'b': 2,
-            'c': {
-                'd': {
-                    'e': 3,
-                    'f': 4,
-                    'g': {
-                        'h': 5,
-                    }
+            "a": 1,
+            "b": 2,
+            "c": {
+                "d": {
+                    "e": 3,
+                    "f": 4,
+                    "g": {
+                        "h": 5,
+                    },
                 }
             },
         }
-        o = _flatten(i, separator='/')
+        o = _flatten(i, separator="/")
         r = {
-            'a': 1,
-            'b': 2,
-            'c/d/e': 3,
-            'c/d/f': 4,
-            'c/d/g/h': 5,
+            "a": 1,
+            "b": 2,
+            "c/d/e": 3,
+            "c/d/f": 4,
+            "c/d/g/h": 5,
         }
         self.assertEqual(o, r)
 
     def test_flatten_with_key_conflict(self):
         i = {
-            'a': 1,
-            'b': 2,
-            'c': {
-                'd': 3,
+            "a": 1,
+            "b": 2,
+            "c": {
+                "d": 3,
             },
-            'c_d': 4,
-            'd_e': 5,
-            'd': {
-                'e': 6,
-            }
+            "c.d": 4,
+            "d_e": 5,
+            "d": {
+                "e": 6,
+            },
         }
         with self.assertRaises(KeyError):
             o = _flatten(i)

--- a/tests/core/test_unflatten.py
+++ b/tests/core/test_unflatten.py
@@ -6,70 +6,69 @@ import unittest
 
 
 class unflatten_test_case(unittest.TestCase):
-
     def test_unflatten(self):
         d = {
-            'a': 1,
-            'b_c': 2,
-            'd_e': 3,
+            "a": 1,
+            "b.c": 2,
+            "d.e": 3,
         }
         u = _unflatten(d)
         r = {
-            'a': 1,
-            'b': {
-                'c': 2,
+            "a": 1,
+            "b": {
+                "c": 2,
             },
-            'd': {
-                'e': 3,
+            "d": {
+                "e": 3,
             },
         }
         self.assertEqual(u, r)
 
     def test_unflatten_with_custom_separator(self):
         d = {
-            'a': 1,
-            'b|c': 2,
-            'd|e': 3,
+            "a": 1,
+            "b|c": 2,
+            "d|e": 3,
         }
-        u = _unflatten(d, separator='#')
+        u = _unflatten(d, separator="#")
         self.assertEqual(u, d)
-        u = _unflatten(d, separator='|')
+        u = _unflatten(d, separator="|")
         r = {
-            'a': 1,
-            'b': {
-                'c': 2,
+            "a": 1,
+            "b": {
+                "c": 2,
             },
-            'd': {
-                'e': 3,
+            "d": {
+                "e": 3,
             },
         }
         self.assertEqual(u, r)
 
     def test_unflatten_with_nested_dict(self):
         d = {
-            'a': 1,
-            'b_c': {
-                'u_v': 2,
+            "a": 1,
+            "b.c": {
+                "u.v": 2,
             },
-            'd_e': {
-                'x_y_z': 3,
+            "d.e": {
+                "x.y.z": 3,
             },
         }
         u = _unflatten(d)
         r = {
-            'a': 1,
-            'b': {
-                'c': {
-                    'u': {
-                        'v': 2,
+            "a": 1,
+            "b": {
+                "c": {
+                    "u": {
+                        "v": 2,
                     },
                 },
             },
-            'd': {
-                'e': {
-                    'x': {
-                        'y': {
-                            'z': 3,
+            "d": {
+                "e": {
+                    "x": {
+                        "y": {
+                            "z": 3,
                         },
                     },
                 },


### PR DESCRIPTION
i found inconsist use of the default keypath_separator.

- sometimes it is "_", 
- sometimes it is "."

i think "_" is a usual separator for convinient naming e.g. "user_name",
so i hope you would accept "." as a default keypath_separator 
(which was already used in some places)

i tried to fix three occurencies of keypath_separator="_" -> to "."
and found the tests for it (hope i fixed them).

however this change need adoption of more tests, which should be easy.
 i looked into them, but as i was not sure what you are testing in some functions i left them unchanged.

this fix solves the issue #63 - for me at least 