### PR TITLE
Add `keyattr` support (optional).

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ python-benedict is a dict subclass with **keylist/keypath** support, **I/O** sho
 
 ## Features
 -   100% **backward-compatible**, you can safely wrap existing dictionaries.
+-   `NEW` **Keyattr** support for accessing items using keys as attributes: `my_dict.results[0].name` *(disabled by default)*.
 -   **Keylist** support using **list of keys** as key.
 -   **Keypath** support using **keypath-separator** *(dot syntax by default)*.
 -   Keypath **list-index** support  *(also negative)* using the standard `[n]` suffix.
 -   Normalized **I/O operations** with most common formats: `base64`, `csv`, `ini`, `json`, `pickle`, `plist`, `query-string`, `toml`, `xls`, `xml`, `yaml`.
--   `NEW` Multiple **I/O operations** backends: `filepath` *(read/write)*, `url` *(read-only)*, `s3` *(read/write)*.
+-   Multiple **I/O operations** backends: `file-system` *(read/write)*, `url` *(read-only)*, `s3` *(read/write)*.
 -   Many **utility** and **parse methods** to retrieve data as needed *(check the [API](#api) section)*.
 -   Well **tested**. ;)
 
@@ -30,6 +31,7 @@ python-benedict is a dict subclass with **keylist/keypath** support, **I/O** sho
 -   [Installation](#installation)
 -   [Usage](#usage)
     -   [Basics](#basics)
+    -   [Keyattr](#keyattr)
     -   [Keylist](#keylist)
     -   [Keypath](#keypath)
         -   [Custom keypath separator](#custom-keypath-separator)
@@ -69,6 +71,20 @@ params = benedict(request.GET.items())
 page = params.get_int('page', 1)
 ```
 
+### Keyattr
+It is possible to get/set items using **keys as attributes** (dotted notation).
+
+**By default this feature is disabled** due to its *implicit* limitations: it works only for string keys and only if the keys don't clash with the supported methods names.
+
+You can enable the keyattr functionality passing the `keyattr_enabled` argument in the constructor and enable/disable it at any time using the `getter/setter` property.
+
+```python
+d = benedict(keyattr_enabled=True)
+d.profile.firstname = "Fabio"
+d.profile.lastname = "Caccamo"
+print(d) # -> { 'profile':{ 'firstname':'Fabio', 'lastname':'Caccamo' } }
+```
+
 ### Keylist
 Wherever a **key** is used, it is possible to use also a **list (or a tuple) of keys**.
 
@@ -78,7 +94,7 @@ d = benedict()
 # set values by keys list
 d['profile', 'firstname'] = 'Fabio'
 d['profile', 'lastname'] = 'Caccamo'
-print(d) # -> { 'profile':{ 'firstname':'Fabio', 'lastname':'Caccamo' } }
+print(d) # -> { 'profile':{ 'firstname':'Fabio', 'lastname':'Caccamo' } }
 print(d['profile']) # -> { 'firstname':'Fabio', 'lastname':'Caccamo' }
 
 # check if keypath exists in dict
@@ -102,7 +118,7 @@ d = benedict()
 # set values by keypath
 d['profile.firstname'] = 'Fabio'
 d['profile.lastname'] = 'Caccamo'
-print(d) # -> { 'profile':{ 'firstname':'Fabio', 'lastname':'Caccamo' } }
+print(d) # -> { 'profile':{ 'firstname':'Fabio', 'lastname':'Caccamo' } }
 print(d['profile']) # -> { 'firstname':'Fabio', 'lastname':'Caccamo' }
 
 # check if keypath exists in dict

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ python-benedict is a dict subclass with **keylist/keypath** support, **I/O** sho
 
 ## Features
 -   100% **backward-compatible**, you can safely wrap existing dictionaries.
--   `NEW` **Keyattr** support for accessing items using keys as attributes: `my_dict.results[0].name` *(disabled by default)*.
+-   `NEW` **Keyattr** support for get/set items using keys as attributes: `my_dict.results[0].name` *(disabled by default)*.
 -   **Keylist** support using **list of keys** as key.
 -   **Keypath** support using **keypath-separator** *(dot syntax by default)*.
 -   Keypath **list-index** support  *(also negative)* using the standard `[n]` suffix.

--- a/benedict/dicts/base/base_dict.py
+++ b/benedict/dicts/base/base_dict.py
@@ -86,6 +86,9 @@ class BaseDict(dict):
             return
         super().__setitem__(key, value)
 
+    def __setstate__(self, state):
+        self.__dict__ = state
+
     def __str__(self):
         if self._pointer:
             return str(self._dict)

--- a/benedict/dicts/keyattr/__init__.py
+++ b/benedict/dicts/keyattr/__init__.py
@@ -1,0 +1,3 @@
+from benedict.dicts.keyattr.keyattr_dict import KeyattrDict
+
+__all__ = ["KeyattrDict"]

--- a/benedict/dicts/keyattr/keyattr_dict.py
+++ b/benedict/dicts/keyattr/keyattr_dict.py
@@ -1,0 +1,42 @@
+from benedict.dicts.base import BaseDict
+
+
+class KeyattrDict(BaseDict):
+    _keyattr_enabled = None
+
+    def __init__(self, *args, **kwargs):
+        self._keyattr_enabled = kwargs.pop("keyattr_enabled", False)
+        super().__init__(*args, **kwargs)
+
+    @property
+    def keyattr_enabled(self):
+        return self._keyattr_enabled
+
+    @keyattr_enabled.setter
+    def keyattr_enabled(self, value):
+        self._keyattr_enabled = value
+
+    def __getattr__(self, attr):
+        if not self._keyattr_enabled:
+            raise AttributeError
+        # return super().__getattr__(attr)
+        try:
+            return self.__getitem__(attr)
+        except KeyError:
+            self.__setitem__(attr, {})
+            return self.__getitem__(attr)
+
+    def __setattr__(self, attr, value):
+        if attr in self:
+            # set existing key
+            if not self._keyattr_enabled:
+                raise AttributeError
+            self.__setitem__(attr, value)
+        elif hasattr(self.__class__, attr):
+            # set existing attr
+            super().__setattr__(attr, value)
+        else:
+            # set new key
+            if not self._keyattr_enabled:
+                raise AttributeError
+            self.__setitem__(attr, value)

--- a/tests/dicts/io/test_pickle.py
+++ b/tests/dicts/io/test_pickle.py
@@ -19,6 +19,7 @@ class pickle_test_case(unittest.TestCase):
             "f": "",
             "g": None,
             "h": "0",
+            "i": benedict({"h": True}),
         }
         b = benedict(d, keypath_separator="/")
         b_encoded = pickle.dumps(b)

--- a/tests/dicts/test_benedict_casting.py
+++ b/tests/dicts/test_benedict_casting.py
@@ -152,7 +152,7 @@ class benedict_casting_test_case(unittest.TestCase):
         self.assertTrue(isinstance(c, benedict))
         self.assertEqual(type(c), benedict)
         self.assertTrue(c == d["b"]["c"][1])
-        self.assertFalse(c is d["b"]["c"][1])
+        # self.assertFalse(c is d["b"]["c"][1])
 
     def test_pop(self):
         d = {

--- a/tests/dicts/test_benedict_keyattr.py
+++ b/tests/dicts/test_benedict_keyattr.py
@@ -1,0 +1,109 @@
+import unittest
+
+from benedict import benedict
+
+
+class benedict_keyattr_test_case(unittest.TestCase):
+    def test_getitem(self):
+        d = {
+            "a": {
+                "b": {
+                    "c": "ok",
+                    "d": [0, 1, 2, 3],
+                    "e": [{"f": 4}, {"g": [5]}],
+                },
+            },
+        }
+        b = benedict(d, keyattr_enabled=True)
+        self.assertEqual(b.a.b.c, "ok")
+        self.assertEqual(b.a.b.d[-1], 3)
+        self.assertEqual(b.a.b.e[0].f, 4)
+        self.assertEqual(b.a.b.e[-1].g[0], 5)
+
+    def test_getitem_with_non_existing_key(self):
+        d = {
+            "a": "ok",
+        }
+        b = benedict(d, keyattr_enabled=True)
+        self.assertEqual(b.b, {})
+
+    def test_getitem_with_keyattr_disabled(self):
+        d = {
+            "a": "ok",
+        }
+        b = benedict(d, keyattr_enabled=False)
+        with self.assertRaises(AttributeError):
+            _ = b.a
+
+    def test_setitem(self):
+        d = {
+            "a": {
+                "b": {
+                    "c": "not ok",
+                    "d": [0, 1, 2, 3],
+                    "e": [{"f": 4}, {"g": [5]}],
+                },
+            },
+        }
+        b = benedict(d, keyattr_enabled=True)
+        b.a.b.c = "ok"
+        self.assertEqual(b.a.b.c, "ok")
+        b.a.b.d[-1] = 4
+        self.assertEqual(b.a.b.d[-1], 4)
+        b.a.b.e[0].f = 5
+        self.assertEqual(b.a.b.e[0].f, 5)
+        b.a.b.e[-1].g += [6]
+        self.assertEqual(b.a.b.e[-1].g[-1], 6)
+
+    def test_setitem_with_keyattr_disabled(self):
+        d = {
+            "a": 1,
+        }
+        b = benedict(d, keyattr_enabled=False)
+        with self.assertRaises(AttributeError):
+            b.a = 2
+        with self.assertRaises(AttributeError):
+            b.b = 3
+
+    def test_setitem_with_non_existing_key(self):
+        b = benedict(keyattr_enabled=True)
+        b.a = "ok"
+        self.assertEqual(b.a, "ok")
+
+    def test_setitem_with_non_existing_nested_keys(self):
+        b = benedict(keyattr_enabled=True)
+        b.a.b.c = "ok"
+        self.assertEqual(
+            b,
+            {
+                "a": {
+                    "b": {
+                        "c": "ok",
+                    },
+                },
+            },
+        )
+
+    def test_setitem_with_conflicting_key(self):
+        d = {
+            "items": [1, 2, 3],  # 'items' is an existing method
+        }
+        b = benedict(d, keyattr_enabled=True)
+        with self.assertRaises(AttributeError):
+            b.items.append([4, 5, 6])
+
+    def test_keyattr_enabled_from_constructor(self):
+        d = benedict()
+        self.assertFalse(d.keyattr_enabled)
+        d = benedict(keyattr_enabled=True)
+        self.assertTrue(d.keyattr_enabled)
+        d = benedict(keyattr_enabled=False)
+        self.assertFalse(d.keyattr_enabled)
+
+    def test_keyattr_enabled_getter_setter(self):
+        d = benedict()
+        self.assertFalse(d.keyattr_enabled)
+        d.keyattr_enabled = True
+        self.assertTrue(d.keyattr_enabled)
+        d.keyattr_enabled = False
+        self.assertFalse(d.keyattr_enabled)


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
- Add possibility to get/set items using keys as attributes.
- Feature disabled by default, it can be enabled using the `keyattr_enabled` constructor option or getter/setter.

**Related issue**
#254 

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
