### PR TITLE
Added cli_serializer & from_cli function

### DIFF
--- a/benedict/dicts/io/io_dict.py
+++ b/benedict/dicts/io/io_dict.py
@@ -173,6 +173,16 @@ class IODict(BaseDict):
         """
         return cls(s, format="yaml", **kwargs)
 
+    @classmethod
+    def from_cli(cls, s, **kwargs):
+        """
+        Load and decode data from a string of CLI arguments.
+        ArgumentParser specific options can be passed using kwargs:
+        https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser
+        Return a new dict instance. A ValueError is raised in case of failure.
+        """
+        return cls(s, format="cli", **kwargs)
+
     def to_base64(self, subformat="json", encoding="utf-8", **kwargs):
         """
         Encode the current dict instance in Base64 format

--- a/benedict/serializers/__init__.py
+++ b/benedict/serializers/__init__.py
@@ -2,6 +2,7 @@ import re
 
 from benedict.serializers.abstract import AbstractSerializer
 from benedict.serializers.base64 import Base64Serializer
+from benedict.serializers.cli import CLISerializer
 from benedict.serializers.csv import CSVSerializer
 from benedict.serializers.ini import INISerializer
 from benedict.serializers.json import JSONSerializer
@@ -16,6 +17,7 @@ from benedict.serializers.yaml import YAMLSerializer
 __all__ = [
     "AbstractSerializer",
     "Base64Serializer",
+    "CLISerializer",
     "CSVSerializer",
     "INISerializer",
     "JSONSerializer",
@@ -29,6 +31,7 @@ __all__ = [
 ]
 
 _BASE64_SERIALIZER = Base64Serializer()
+_CLI_SERIALIZER = CLISerializer()
 _CSV_SERIALIZER = CSVSerializer()
 _INI_SERIALIZER = INISerializer()
 _JSON_SERIALIZER = JSONSerializer()
@@ -42,6 +45,7 @@ _YAML_SERIALIZER = YAMLSerializer()
 
 _SERIALIZERS_LIST = [
     _BASE64_SERIALIZER,
+    _CLI_SERIALIZER,
     _CSV_SERIALIZER,
     _INI_SERIALIZER,
     _JSON_SERIALIZER,

--- a/benedict/serializers/cli.py
+++ b/benedict/serializers/cli.py
@@ -27,7 +27,7 @@ class CLISerializer(AbstractSerializer):
 
     @staticmethod
     def _get_parser(options):
-        parser = ArgumentParser(exit_on_error=False, **options)
+        parser = ArgumentParser(**options)
         return parser
 
     def decode(self, s=None, **kwargs):

--- a/benedict/serializers/cli.py
+++ b/benedict/serializers/cli.py
@@ -5,25 +5,46 @@ from re import finditer
 from benedict.serializers.abstract import AbstractSerializer
 from benedict.utils import type_util
 
-regex_keys_with_values = r"-+\w+(?=\s[^\s-])"
-regex_all_keys = r"-+\w+"
-
-
-def parse_keys(regex, string):
-    # For some reason findall didn't work
-    results = [match.group(0) for match in finditer(regex, string)]
-    return results
-
 
 class CLISerializer(AbstractSerializer):
     """
     This class describes a CLI serializer.
     """
 
+    regex_keys_with_values = r"-+\w+(?=\s[^\s-])"
+    """
+    Regex string.
+    Used to search for keys (e.g. -STRING or --STRING)
+    that *aren't* followed by another key
+
+    Example input: script.py --username example --verbose -d -e email@example.com
+    - Matches: --username, -e
+    - Doesn't match: script.py, example, --verbose, -d, email@example.com
+    """
+
+    regex_all_keys = r"-+\w+"
+    """
+    Regex string.
+    Used to search for keys (e.g. -STRING or --STRING)
+    no matter if they are followed by another key
+
+    Example input: script.py --username example --verbose -d -e email@example.com
+    - Matches: --username, --verbose, -d, -e
+    - Doesn't match: script.py, example, email@example.com
+    """
+
     def __init__(self):
         super().__init__(
             extensions=["cli"],
         )
+
+    @staticmethod
+    def parse_keys(regex, string):
+        # For some reason findall didn't work
+        results = [match.group(0) for match in finditer(regex, string)]
+        return results
+
+    """Helper method, returns a list of --keys based on the regex used"""
 
     @staticmethod
     def _get_parser(options):
@@ -33,40 +54,42 @@ class CLISerializer(AbstractSerializer):
     def decode(self, s=None, **kwargs):
         parser = self._get_parser(options=kwargs)
 
-        keys_with_values = set(parse_keys(regex_keys_with_values, s))
-        all_keys = Counter(parse_keys(regex_all_keys, s))
+        keys_with_values = set(self.parse_keys(self.regex_keys_with_values, s))
+        all_keys = Counter(self.parse_keys(self.regex_all_keys, s))
         for key in all_keys:
             count = all_keys[key]
 
-            # If the key has a value...
-            if key in keys_with_values:
-                # and is defined once, collect the values
-                if count == 1:
-                    parser.add_argument(
-                        key,
-                        nargs="*",
-                        # This puts multiple values in a list
-                        # even though this won't always be wanted
-                        # This is adressed after the dict is generated
-                        required=False,
-                    )
-                # and is defined multiple times, collect the values
-                else:
-                    parser.add_argument(key, action="append", required=False)
+            try:
+                # If the key has a value...
+                if key in keys_with_values:
+                    # and is defined once, collect the values
+                    if count == 1:
+                        parser.add_argument(
+                            key,
+                            nargs="*",
+                            # This puts multiple values in a list
+                            # even though this won't always be wanted
+                            # This is adressed after the dict is generated
+                            required=False,
+                        )
+                    # and is defined multiple times, collect the values
+                    else:
+                        parser.add_argument(key, action="append", required=False)
 
-            # If the key doesn't have a value...
-            else:
-                # and is defined once, store as bool
-                if count <= 1:
-                    parser.add_argument(key, action="store_true", required=False)
-                # and is defined multiple times, count how many times
+                # If the key doesn't have a value...
                 else:
-                    parser.add_argument(key, action="count", required=False)
+                    # and is defined once, store as bool
+                    if count <= 1:
+                        parser.add_argument(key, action="store_true", required=False)
+                    # and is defined multiple times, count how many times
+                    else:
+                        parser.add_argument(key, action="count", required=False)
+
+            except ArgumentError as error:
+                raise ValueError from error
 
         try:
             args = parser.parse_args(s.split())
-        except ArgumentError as error:
-            raise ValueError from error
         except BaseException as error:
             raise ValueError from error
 

--- a/benedict/serializers/cli.py
+++ b/benedict/serializers/cli.py
@@ -1,0 +1,81 @@
+from argparse import ArgumentError, ArgumentParser
+from collections import Counter
+from re import finditer
+
+from benedict.serializers.abstract import AbstractSerializer
+from benedict.utils import type_util
+
+regex_keys_with_values = r"-+\w+(?=\s[^\s-])"
+regex_all_keys = r"-+\w+"
+
+
+def parse_keys(regex, string):
+    # For some reason findall didn't work
+    results = [match.group(0) for match in finditer(regex, string)]
+    return results
+
+
+class CLISerializer(AbstractSerializer):
+    """
+    This class describes a CLI serializer.
+    """
+
+    def __init__(self):
+        super().__init__(
+            extensions=["cli"],
+        )
+
+    @staticmethod
+    def _get_parser(options):
+        parser = ArgumentParser(exit_on_error=False, **options)
+        return parser
+
+    def decode(self, s=None, **kwargs):
+        parser = self._get_parser(options=kwargs)
+
+        keys_with_values = set(parse_keys(regex_keys_with_values, s))
+        all_keys = Counter(parse_keys(regex_all_keys, s))
+        for key in all_keys:
+            count = all_keys[key]
+
+            # If the key has a value...
+            if key in keys_with_values:
+                # and is defined once, collect the values
+                if count == 1:
+                    parser.add_argument(
+                        key,
+                        nargs="*",
+                        # This puts multiple values in a list
+                        # even though this won't always be wanted
+                        # This is adressed after the dict is generated
+                        required=False,
+                    )
+                # and is defined multiple times, collect the values
+                else:
+                    parser.add_argument(key, action="append", required=False)
+
+            # If the key doesn't have a value...
+            else:
+                # and is defined once, store as bool
+                if count <= 1:
+                    parser.add_argument(key, action="store_true", required=False)
+                # and is defined multiple times, count how many times
+                else:
+                    parser.add_argument(key, action="count", required=False)
+
+        try:
+            args = parser.parse_args(s.split())
+        except ArgumentError as error:
+            raise ValueError from error
+        except BaseException as error:
+            raise ValueError from error
+
+        dict = vars(args)
+        for key in dict:
+            value = dict[key]
+            # If only one value was written,
+            # return that value instead of a list
+            if type_util.is_list(value) and len(value) == 1:
+                dict[key] = value[0]
+
+        return dict

--- a/tests/dicts/io/test_io_dict_cli.py
+++ b/tests/dicts/io/test_io_dict_cli.py
@@ -1,0 +1,37 @@
+from benedict.dicts.io import IODict
+
+from .test_io_dict import io_dict_test_case
+
+
+class io_dict_cli_test_case(io_dict_test_case):
+    """
+    This class describes an IODict / cli test case.
+    """
+
+    def test_from_cli_with_valid_data(self):
+        s = """--url "https://github.com" --usernames another handle --languages Python --languages JavaScript -v --count --count --count"""
+        # static method
+        r = {
+            "url": '"https://github.com"',
+            "usernames": ["another", "handle"],
+            "languages": ["Python", "JavaScript"],
+            "v": True,
+            "count": 3,
+        }
+
+        d = IODict.from_cli(s)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, r)
+        # constructor
+        d = IODict(s, format="cli")
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, r)
+
+    def test_from_cli_with_invalid_data(self):
+        s = "Lorem ipsum est in ea occaecat nisi officia."
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_cli(s)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(s, format="cli")

--- a/tests/dicts/io/test_io_dict_cli.py
+++ b/tests/dicts/io/test_io_dict_cli.py
@@ -27,6 +27,16 @@ class io_dict_cli_test_case(io_dict_test_case):
         self.assertTrue(isinstance(d, dict))
         self.assertEqual(d, r)
 
+    def test_from_cli_with_invalid_arguments(self):
+        s = """--help -h"""
+
+        # static method
+        with self.assertRaises(ValueError):
+            IODict.from_cli(s)
+        # constructor
+        with self.assertRaises(ValueError):
+            IODict(s, format="cli")
+
     def test_from_cli_with_invalid_data(self):
         s = "Lorem ipsum est in ea occaecat nisi officia."
         # static method


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
- Implemented a from_cli function and its respective serializer + tests

**Related issue/discussion**
https://github.com/fabiocaccamo/python-benedict/discussions/290

**Extra notes:**
- ArgumentParser allows for an auto-generated --help interface, but this not possible in the current implementation. Support for this could be added, but it would require extra top level functions, and I am unsure as to whether that would be overkill or out of scope
- It should be possible to allow from_cli to take 0 arguments, as the internally used parse_args function also allows 0-1 arguments (in case of 0, it takes the arguments passed to the currently running script). However, I don't know if that behaviour is desirable, as it would make from_cli more unlike the other from_* functions
- Technically, to_cli could also be possible (e.g. create a string with the command that would need to be run to get these options), but I don't know if that has much use

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
