### PR TITLE
Add 'sort' parameter to keypaths()

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,8 @@ items = d.items_sorted_by_values(reverse=False)
 ```python
 # Return a list of all keypaths in the dict.
 # If indexes is True, the output will include list values indexes.
-k = d.keypaths(indexes=False)
+# If sort is True, the resulting list will be sorted
+k = d.keypaths(indexes=False, sort=True)
 ```
 
 #### `match`

--- a/benedict/core/keypaths.py
+++ b/benedict/core/keypaths.py
@@ -2,11 +2,12 @@ from benedict.core.keylists import keylists
 from benedict.utils import type_util
 
 
-def keypaths(d, separator=".", indexes=False):
+def keypaths(d, separator=".", indexes=False, sort=True):
     separator = separator or "."
     if not type_util.is_string(separator):
         raise ValueError("separator argument must be a (non-empty) string.")
     kls = keylists(d, indexes=indexes)
     kps = [separator.join([f"{key}" for key in kl]) for kl in kls]
-    kps.sort()
+    if sort:
+        kps.sort()
     return kps

--- a/benedict/dicts/__init__.py
+++ b/benedict/dicts/__init__.py
@@ -196,12 +196,14 @@ class benedict(KeyattrDict, KeypathDict, IODict, ParseDict):
         """
         return _items_sorted_by_values(self, reverse=reverse)
 
-    def keypaths(self, indexes=False):
+    def keypaths(self, indexes=False, sort=True):
         """
         Return a list of all keypaths in the dict.
         If indexes is True, the output will include list values indexes.
         """
-        return _keypaths(self, separator=self._keypath_separator, indexes=indexes)
+        return _keypaths(
+            self, separator=self._keypath_separator, indexes=indexes, sort=sort
+        )
 
     def match(self, pattern, indexes=True):
         """

--- a/tests/core/test_keypaths.py
+++ b/tests/core/test_keypaths.py
@@ -35,6 +35,33 @@ class keypaths_test_case(unittest.TestCase):
         ]
         self.assertEqual(o, r)
 
+    def test_keypaths_unsorted(self):
+        i = {
+            "b": {
+                "c": {
+                    "y": 3,
+                    "x": 2,
+                },
+                "d": {
+                    "x": 4,
+                    "y": 5,
+                },
+            },
+            "a": 1,
+        }
+        o = _keypaths(i, sort=False)
+        r = [
+            "b",
+            "b.c",
+            "b.c.y",
+            "b.c.x",
+            "b.d",
+            "b.d.x",
+            "b.d.y",
+            "a",
+        ]
+        self.assertEqual(o, r)
+
     def test_keypaths_with_custom_separator(self):
         i = {
             "a": 1,


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
The `keypaths()` function sorts the list before returning it. There are use cases where an unsorted list is useful. Added a `sort` parameter which defaults to `True` for backwards compatability. Added unit test, and updated README. This PR based on a patch from @mucmch.

**Related issue**
#404.

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.

I also updated the documentation in `README.md` to show this new parameter.