### PR TITLE
Accept array-style keys in from_query_string

### DIFF
--- a/benedict/serializers/query_string.py
+++ b/benedict/serializers/query_string.py
@@ -30,9 +30,15 @@ class QueryStringSerializer(
     def decode(  # type: ignore[override]
         self, s: str, flat: bool = True
     ) -> dict[str, str] | dict[str, list[str]]:
-        qs_re = r"(?:([\w\-\%\+\.\|]+\=[\w\-\%\+\.\|]*)+(?:[\&]{1})?)+"
-        qs_pattern = re.compile(qs_re)
-        if qs_pattern.match(s):
+        # A query string is a sequence of "key=value" pairs joined by "&".
+        # Each key must be non-empty and free of whitespace, "=" and "&";
+        # each value must be free of whitespace and "&" (spaces are encoded
+        # as "+" or "%20"). This accepts real-world keys such as array-style
+        # "a[]" / "user[name]" while still rejecting other formats (TOML, YAML,
+        # JSON, XML), plain text and URLs.
+        pair_re = re.compile(r"^[^\s=&]+=[^\s&]*$")
+        pairs = s.split("&")
+        if all(pair_re.match(pair) for pair in pairs):
             data = parse_qs(s)
             if flat:
                 return {key: value[0] for key, value in data.items()}

--- a/tests/dicts/io/test_io_dict_query_string.py
+++ b/tests/dicts/io/test_io_dict_query_string.py
@@ -26,6 +26,24 @@ class io_dict_query_string_test_case(io_dict_test_case):
         self.assertTrue(isinstance(d, dict))
         self.assertEqual(d, r)
 
+    def test_from_query_string_with_array_style_keys(self) -> None:
+        # array-style keys (PHP / HTML form syntax) are valid query strings
+        s = "a[]=1&a[]=2"
+        r = {"a[]": "1"}
+        d = IODict.from_query_string(s)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, r)
+        d = IODict(s, format="query_string")
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, r)
+
+    def test_from_query_string_with_bracketed_keys(self) -> None:
+        s = "user[name]=joe&user[age]=42"
+        r = {"user[name]": "joe", "user[age]": "42"}
+        d = IODict.from_query_string(s)
+        self.assertTrue(isinstance(d, dict))
+        self.assertEqual(d, r)
+
     def test_from_query_string_with_invalid_data(self) -> None:
         s = "Lorem ipsum est in ea occaecat nisi officia."
         # static method


### PR DESCRIPTION
### Problem

`from_query_string` rejects valid query strings that use array-style keys, which `urllib.parse.parse_qs` parses without complaint:

```python
from benedict import benedict
benedict.from_query_string("a[]=1&a[]=2")        # ValueError: Invalid query string
benedict.from_query_string("user[name]=joe")     # ValueError: Invalid query string
benedict.from_query_string("items[0]=x&items[1]=y")  # ValueError: Invalid query string
```

The `decode` gate in `QueryStringSerializer` used a hardcoded character whitelist (`[\w\-\%\+\.\|]`) for keys and values, which omits `[` and `]` (and other valid characters), so any bracketed/array key fails the gate before `parse_qs` is ever called. Array-style keys are common (PHP and HTML-form syntax).

### Fix

Replace the opaque whitelist with a structural check: split on `&` and require every segment to be `key=value` where the key is non-empty and neither side contains raw whitespace, `=` (key) or `&`. This accepts bracketed/array keys while still rejecting the other formats benedict's autodetect must distinguish (verified against the repo's own fixtures: TOML, YAML, JSON, XML, plain text and URLs are still rejected).

### Tests

Added cases for array-style (`a[]=1&a[]=2`) and bracketed (`user[name]=joe&user[age]=42`) keys via both `IODict.from_query_string` and `IODict(s, format="query_string")`. Without the fix they raise `ValueError`; with it the query-string tests pass and the broader IO/serializer suite is green (279 passed locally). `ruff check`/`format` clean.

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
