### PR TITLE
fix: anchor string patterns in match() to consume full keypath

### DIFF
--- a/benedict/core/match.py
+++ b/benedict/core/match.py
@@ -21,6 +21,8 @@ def match(
         pattern = re.sub(r"([\*]{1})", "(.)*", pattern)
         # escape square brackets
         pattern = re.sub(r"(\[([^\[\]]*)\])", "\\[\\g<2>\\]", pattern)
+        # anchor to end so the full keypath must be consumed
+        pattern = pattern + "$"
         regex = re.compile(pattern, flags=re.DOTALL)
     else:
         raise ValueError(f"Expected regex or string, found: {type(pattern)}")

--- a/tests/core/test_match.py
+++ b/tests/core/test_match.py
@@ -57,6 +57,17 @@ class match_test_case(unittest.TestCase):
         ]
         self.assertEqual(values, expected_values)
 
+    def test_match_with_suffix_wildcard(self) -> None:
+        # Suffix wildcard like "*.jpg" must not match "IMG_0001.jpg.bak" –
+        # i.e. the full keypath must be consumed, not just a prefix.
+        d = {
+            "IMG_0001.jpg": "IMG_0001.jpg",
+            "IMG_0001.jpg.bak": "IMG_0001.jpg.bak",
+            "DOC_0001.pdf": "DOC_0001.pdf",
+        }
+        values = _match(d, "*.jpg")
+        self.assertEqual(values, ["IMG_0001.jpg"])
+
     def test_match_with_invalid_pattern(self) -> None:
         d = self._get_dict()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Bug

`benedict.match()` converts string wildcard patterns to regex and applies
`regex.match()`, which only verifies a **prefix** match — the rest of the
keypath is silently ignored.

For a pattern like `"*a"` the transformation produces `(.)*a`. Because
`regex.match("ab")` anchors at the start but not the end, it succeeds on
`"ab"` (`.` consumes `"a"`, `a` matches the first character, `"b"` is
left unconsumed). The result: keys that do **not** end in `"a"` are
erroneously returned.

```python
from benedict import benedict

d = benedict({"aa": 1, "ab": 2, "ba": 3, "bb": 4})
d.match("*a")
# Before fix: [1, 2, 3]   ← "ab" wrongly included
# After fix:  [1, 3]      ← only "aa" and "ba"
```

## Fix

Append `"$"` to string-derived patterns before compiling so the full
keypath must be consumed. Raw compiled-regex patterns (`re.Pattern`)
are unaffected and continue to use `regex.match()` as before.

## Tests

Added `test_match_with_suffix_wildcard` to `tests/core/test_match.py`;
all 261 existing core + keypath tests continue to pass.