### PR TITLE
Reject empty keypaths separator

### DIFF
--- a/benedict/core/keypaths.py
+++ b/benedict/core/keypaths.py
@@ -13,8 +13,10 @@ def keypaths(
     indexes: bool = False,
     sort: bool = True,
 ) -> list[str]:
-    separator = separator or "."
+    separator = "." if separator is None else separator
     if not type_util.is_string(separator):
+        raise ValueError("separator argument must be a (non-empty) string.")
+    if not separator:
         raise ValueError("separator argument must be a (non-empty) string.")
     kls = keylists(d, indexes=indexes)
     kps = [separator.join([f"{key}" for key in kl]) for kl in kls]

--- a/benedict/core/keypaths.py
+++ b/benedict/core/keypaths.py
@@ -14,9 +14,7 @@ def keypaths(
     sort: bool = True,
 ) -> list[str]:
     separator = "." if separator is None else separator
-    if not type_util.is_string(separator):
-        raise ValueError("separator argument must be a (non-empty) string.")
-    if not separator:
+    if not type_util.is_string(separator) or not separator:
         raise ValueError("separator argument must be a (non-empty) string.")
     kls = keylists(d, indexes=indexes)
     kps = [separator.join([f"{key}" for key in kl]) for kl in kls]

--- a/tests/core/test_keypaths.py
+++ b/tests/core/test_keypaths.py
@@ -106,6 +106,10 @@ class keypaths_test_case(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = _keypaths(i, separator=True)  # type: ignore[arg-type]
 
+    def test_keypaths_with_empty_separator(self) -> None:
+        with self.assertRaises(ValueError):
+            _ = _keypaths({"a": {"b": 1}}, separator="")
+
     def test_keypaths_without_separator(self) -> None:
         i = {
             "a": 1,


### PR DESCRIPTION
## What changed

`keypaths(..., separator="")` now raises the same `ValueError` as other invalid separators instead of silently falling back to the default `"."` separator.

## Why

The function documents and reports that the separator must be a non-empty string. An explicit empty separator is most likely a caller mistake, and silently converting it to `"."` can hide the invalid input and return keypaths with an unexpected separator.

`separator=None` still preserves the previous default behavior.

## Validation

- `python -m pytest tests\core\test_keypaths.py -q`
- `python -m pytest tests\core -q`
- `python -m ruff check benedict\core\keypaths.py tests\core\test_keypaths.py`
- `python -m black --check benedict\core\keypaths.py tests\core\test_keypaths.py`
- `git diff --check`