### PR TITLE
fix: handle non-string dict keys holding lists in keylists/keypaths

### DIFF
--- a/benedict/core/keylists.py
+++ b/benedict/core/keylists.py
@@ -23,7 +23,10 @@ def _get_keylist_for_list(
     keylist = []
     for key, value in enumerate(ls):
         keys = list(parent_keys)
-        keys[-1] += f"[{key}]"
+        # Stringify the parent key before appending the index so non-string keys
+        # (e.g. int/None/bool) holding a list don't raise a TypeError. String keys
+        # are unaffected: f"{'a'}[0]" == "a[0]".
+        keys[-1] = f"{keys[-1]}[{key}]"
         keylist += [keys]
         keylist += _get_keylist_for_value(value, keys, indexes)
     return keylist

--- a/tests/core/test_keylists.py
+++ b/tests/core/test_keylists.py
@@ -60,6 +60,29 @@ class keylists_test_case(unittest.TestCase):
         for k in r:
             self.assertTrue(k in o)
 
+    def test_keylists_with_non_string_keys_and_lists_and_indexes_included(
+        self,
+    ) -> None:
+        # A non-string key (int/None/bool) holding a list used to raise
+        # 'TypeError: unsupported operand type(s) for +=: 'int' and 'str''
+        # while the same key holding a dict worked fine.
+        i = {
+            0: [1, 2],
+            None: [3, 4],
+        }
+        o = _keylists(i, indexes=True)
+        r = [
+            [0],
+            ["0[0]"],
+            ["0[1]"],
+            [None],
+            ["None[0]"],
+            ["None[1]"],
+        ]
+        self.assertEqual(len(o), len(r))
+        for k in r:
+            self.assertTrue(k in o)
+
     def test_keylists_with_lists_and_indexes_included(self) -> None:
         i = {
             "a": 1,


### PR DESCRIPTION
## Summary

`keylists(d, indexes=True)` raises `TypeError` whenever a **non-string dict key** (int / `None` / bool / tuple) holds a **list** value. Because `keypaths`, `match`, and the public `benedict.keypaths()` / `benedict.keylists()` all build on `keylists`, the crash also surfaces through the public API.

## Reproduce

```python
from benedict import benedict

benedict({0: [1, 2]}).keypaths(indexes=True)
# TypeError: unsupported operand type(s) for +=: 'int' and 'str'

from benedict.core.keylists import keylists
keylists({0: [1, 2]}, indexes=True)      # TypeError
keylists({None: [1, 2]}, indexes=True)   # TypeError
```

## Root cause

In `benedict/core/keylists.py`, `_get_keylist_for_list` appended the list index to the parent key with:

```python
keys[-1] += f"[{key}]"
```

This assumes the last parent key is a **string**. A string key `"a"` becomes `"a[0]"`, but an int key `0` evaluates `0 += "[0]"` and crashes.

The behaviour was **inconsistent**: the *same* non-string key holding a **dict** worked fine, and non-string keys are explicitly supported elsewhere in the module (see the existing `test_keylists_with_non_string_keys`). Only the list branch assumed stringness.

| input | `keylists(..., indexes=True)` before | after |
|---|---|---|
| `{"a": [1, 2]}` | `[['a'], ['a[0]'], ['a[1]']]` | `[['a'], ['a[0]'], ['a[1]']]` (unchanged) |
| `{0: {"x": 1}}` | `[[0], [0, 'x']]` | `[[0], [0, 'x']]` (unchanged) |
| `{0: [1, 2]}` | **TypeError** | `[[0], ['0[0]'], ['0[1]']]` |
| `{None: [1, 2]}` | **TypeError** | `[[None], ['None[0]'], ['None[1]']]` |

## Fix

Stringify the parent key before appending the index:

```python
keys[-1] = f"{keys[-1]}[{key}]"
```

String keys are unaffected (`f"{'a'}[0]" == "a[0]"`); non-string keys now produce a consistent stringified keypath (`0` → `"0[0]"`, `None` → `"None[0]"`), matching how `keypaths` already stringifies every key via `f"{key}"`.

## Tests

Added `test_keylists_with_non_string_keys_and_lists_and_indexes_included`, which follows the existing `test_keylists_with_non_string_keys` membership style (mixed int/str/None keylists can't be sorted for comparison).

Proven to guard the bug — stash the source fix and the new test fails with the original `TypeError` at `keylists.py:26`; restore the fix and it passes:

```
# without fix
FAILED tests/core/test_keylists.py::keylists_test_case::test_keylists_with_non_string_keys_and_lists_and_indexes_included
  E   TypeError: unsupported operand type(s) for +=: 'int' and 'str'
  benedict/core/keylists.py:26: TypeError

# with fix
tests/core/test_keylists.py ... 1 passed
```

Full `tests/core` + `tests/utils` suite: **123 passed** (was 122). `ruff check`, `ruff format --check`, `black --check` and `mypy` are all clean on the changed files (the 3 pre-existing mypy errors in `serializers/*` and `parse_util.py` are unrelated optional-dependency stub issues, present with or without this change).

Diff: **+27 / −1** across `benedict/core/keylists.py` and `tests/core/test_keylists.py`.
