### PR TITLE
Fix RecursionError when assigning a benedict into its own nested descendant (#592)

### DIFF
--- a/benedict/dicts/base/base_dict.py
+++ b/benedict/dicts/base/base_dict.py
@@ -22,15 +22,32 @@ class BaseDict(dict[_K, _V]):
     _dict: dict[_K, _V] | None
     _frozen: bool
 
+    # ids of mappings being unwrapped anywhere on the call stack, to detect
+    # self-referential structures instead of recursing forever
+    _unwrapping_ids: set[int] = set()
+
     @classmethod
     def _get_dict_or_value(cls, value: Any) -> Any:
         value = value.dict() if isinstance(value, cls) else value
         if isinstance(value, MutableMapping):
-            for key in value.keys():
-                key_val = value[key]
-                if isinstance(key_val, cls):
-                    key_val = cls._get_dict_or_value(value[key])
-                    value[key] = key_val
+            value_id = id(value)
+            if value_id in cls._unwrapping_ids:
+                # it contains itself; unwind here before reaching code with no cycle
+                # protection of its own
+                raise ValueError(
+                    "Cannot assign a dict that contains itself "
+                    "(directly or indirectly): self-referential "
+                    "(cyclic) structures are not supported."
+                )
+            cls._unwrapping_ids.add(value_id)
+            try:
+                for key in value.keys():
+                    key_val = value[key]
+                    if isinstance(key_val, cls):
+                        key_val = cls._get_dict_or_value(value[key])
+                        value[key] = key_val
+            finally:
+                cls._unwrapping_ids.discard(value_id)
         return value
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:

--- a/tests/github/test_issue_0592.py
+++ b/tests/github/test_issue_0592.py
@@ -1,0 +1,44 @@
+import unittest
+
+from benedict import benedict
+
+
+class github_issue_0592_test_case(unittest.TestCase):
+    """
+    This class describes a github issue 0592 test case.
+    https://github.com/fabiocaccamo/python-benedict/issues/592
+
+    To run this specific test:
+    - Run python -m unittest tests.github.test_issue_0592
+    """
+
+    def test_assigning_dict_to_its_own_nested_descendant_does_not_raise(self) -> None:
+        # not self-referential yet at assignment time, so it must keep working
+        d = benedict(keyattr_enabled=True, keyattr_dynamic=True)
+        d.a.b.c = d
+        self.assertIs(dict.__getitem__(d, "a")["b"]["c"], d)
+
+    def test_assigning_dict_to_its_own_nested_descendant_twice_does_not_recurse(
+        self,
+    ) -> None:
+        # once `d` contains itself, unwrapping it again must not raise
+        # RecursionError (it used to crash the process)
+        d = benedict(keyattr_enabled=True, keyattr_dynamic=True)
+        d.a.b.c = d
+        with self.assertRaises(ValueError):
+            d.a.b.d.e = d
+
+    def test_self_assignment_at_new_key_still_works(self) -> None:
+        # assigning a dict to itself under a new key is unaffected by the fix
+        d = benedict({"a": {"b": 1}})
+        d["self"] = d
+        self.assertIsInstance(d["self"], benedict)
+        self.assertEqual(d["self"]["a"], {"b": 1})
+
+    def test_normal_nested_dict_assignment_is_unaffected(self) -> None:
+        # non self-referential values must still be unwrapped as before
+        inner = benedict({"x": 1})
+        outer = benedict()
+        outer["inner"] = inner
+        self.assertEqual(outer, {"inner": {"x": 1}})
+        self.assertIsNot(outer["inner"], inner)


### PR DESCRIPTION

## Problem

https://github.com/fabiocaccamo/python-benedict/issues/592

Assigning a `benedict` into a nested descendant of itself works once, but a
second such assignment crashes with `RecursionError` (and, per the issue,
can crash a Jupyter kernel):

```python
from benedict import benedict

test = benedict(keyattr_enabled=True, keyattr_dynamic=True)
test.a.b.c = test        # works
test.a.b.d.e = test      # RecursionError: maximum recursion depth exceeded
```

## Root cause

`BaseDict._get_dict_or_value()` in `benedict/dicts/base/base_dict.py` (lines
25-34 on `main`) recursively unwraps nested `benedict` values with no cycle
detection, and it is called from every `__init__`/`__setitem__`/`update`/
`setdefault`. After the first assignment, `test` contains a value that
(transitively) is `test` itself. Any later operation that needs to unwrap
`test` again (eg. navigating `test.a` to perform the second assignment)
recurses into that self-reference and never terminates.

The actual recursion is not a simple self-call of `_get_dict_or_value`: it
alternates between `_get_dict_or_value`, `_cast`/`__init__` (which wrap the
same underlying raw dict into a fresh `benedict` object on every access) and
`__setitem__` -> `check_keys`/`traverse` (`benedict/core/traverse.py`, which
has no cycle protection of its own either). All of these frames belong to
one continuous call stack, so a cycle guard confined to
`_get_dict_or_value` still sees the re-entry and can stop the whole chain
before the uncontrolled recursion is ever reached elsewhere.

## Fix

`benedict/dicts/base/base_dict.py`: `_get_dict_or_value` now tracks, in a
class-level `_unwrapping_ids` set, the `id()` of every mapping it is
currently in the middle of unwrapping (added on entry, removed via
`finally` on exit -- so it only ever reflects containers that are live on
the *current* call stack, not a permanent "already seen" memo, which would
incorrectly flag legitimate shared/aliased references as cycles). If a
mapping is encountered while it is already being unwrapped higher up the
stack, the structure is self-referential: instead of recursing again (which
would eventually blow the stack, potentially inside unrelated,
unprotected code such as `check_keys`/`traverse`), a `ValueError` is raised
immediately, unwinding the whole unwrap/cast chain in a controlled way.

Normal (non-cyclic) nested-dict unwrapping is unaffected: the guard is only
ever populated with ids of mappings still being processed, and a proper
(acyclic) tree can never revisit a node that is still being visited, so the
new code paths are simply never exercised for legitimate data.

Scope note: a complete "silently supported" self-reference (making the
*second* assignment succeed rather than raise) is not achievable without
also touching `benedict/core/traverse.py`'s `_traverse_dict`/
`_traverse_collection` (used, via `check_keys`, on every `__setitem__`, and
also by several other public APIs such as `merge`/`flatten`/`keypaths`),
since that traversal is independently unprotected against cycles. That was
considered out of scope for a minimal, low-risk fix, so this change turns
the uncontrolled `RecursionError` into a clear, immediate `ValueError`
instead.
